### PR TITLE
Revert "Change in tests "Altom" name in imports for C# package"

### DIFF
--- a/New Input System proj/Assets/Editor/Tests/AltTester_NIS_Tests.cs
+++ b/New Input System proj/Assets/Editor/Tests/AltTester_NIS_Tests.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using AltTester.AltDriver;
+using Altom.AltDriver;
 using System.Threading;
 using UnityEngine;
 


### PR DESCRIPTION
Reverts alttester/EXAMPLES-NewInputSystem--CoinCollector-CSharp#6