### PR TITLE
Revert "Revert "Change in tests "Altom" name in imports for C# package""

### DIFF
--- a/New Input System proj/Assets/Editor/Tests/AltTester_NIS_Tests.cs
+++ b/New Input System proj/Assets/Editor/Tests/AltTester_NIS_Tests.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 using System.Threading;
 using UnityEngine;
 

--- a/New Input System proj/Assets/Editor/Tests/AltTester_NIS_Tests.cs
+++ b/New Input System proj/Assets/Editor/Tests/AltTester_NIS_Tests.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using Altom.AltDriver;
+using AltTester.AltDriver;
 using System.Threading;
 using UnityEngine;
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This project contains C# AltTester tests for a project using the New Input Syste
 The tested actions are: tap object, key down/ key up, press key, click object, scroll, begin/end touch and tap simulated with swipe.
 
 ## Before running the tests
+❗ Starting with version 2.0.0, the AltTester Desktop must be running on your PC while the tests are running.
 To run the tests, you must include the AltTester Unity SDK in the project. To do that, you can choose between the following ways:
 1. Install the [AltTesterDesktop](https://alttester.com/app/uploads/AltTester/desktop/AltTesterDesktopPackageMac__v2.0.1.zip), then open it.
 2. Add the AltTester Unity SDK submodule to the project

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The tested actions are: tap object, key down/ key up, press key, click object, s
 ## Before running the tests
 ❗ Starting with version 2.0.0, the AltTester Desktop must be running on your PC while the tests are running.
 
-- Install the [AltTesterDesktop](https://alttester.com/app/uploads/AltTester/desktop/AltTesterDesktopPackageMac__v2.0.1.zip), then open it.
+- Install the [AltTesterDesktop](https://alttester.com/alttester/#pricing), then open it.
 - To run the tests, you must include the AltTester Unity SDK in the project. To do that, you can choose between the following ways:
 1. Add the AltTester Unity SDK submodule to the project
     - use ``git submodule update --init`` command to pull the git submodule;

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ The tested actions are: tap object, key down/ key up, press key, click object, s
 
 ## Before running the tests
 To run the tests, you must include the AltTester Unity SDK in the project. To do that, you can choose between the following ways:
-1. Add the AltTester Unity SDK submodule to the project
+1. Install the [AltTesterDesktop](https://alttester.com/app/uploads/AltTester/desktop/AltTesterDesktopPackageMac__v2.0.1.zip), then open it.
+2. Add the AltTester Unity SDK submodule to the project
     - use ``git submodule update --init`` command to pull the git submodule;
     - make sure that the submodule added is on the master branch (you can use the following command ``git checkout master`` in the <i>Assets/AltTester-Unity-SDK</i> folder);
     - also, if you already have the project, you should make a ``git pull`` on the master branch, in order to ensure that you are using the latest version of AltTester.
 
     <br> 
-2. Download AltTester Unity SDK and import it into Unity 
+3. Download AltTester Unity SDK and import it into Unity 
     - download the AltTester Unity SDK from the Altom website (https://altom.com/testing-tools/alttester/) or using this link https://altom.com/app/uploads/AltTester/sdks/AltTester.unitypackage;
     - import the package into the project (drag-n-drop the package in the Assets folder);
     - a pop-up will appear, select All and click on Import.

--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@ The tested actions are: tap object, key down/ key up, press key, click object, s
 
 ## Before running the tests
 ❗ Starting with version 2.0.0, the AltTester Desktop must be running on your PC while the tests are running.
-To run the tests, you must include the AltTester Unity SDK in the project. To do that, you can choose between the following ways:
-1. Install the [AltTesterDesktop](https://alttester.com/app/uploads/AltTester/desktop/AltTesterDesktopPackageMac__v2.0.1.zip), then open it.
-2. Add the AltTester Unity SDK submodule to the project
+
+- Install the [AltTesterDesktop](https://alttester.com/app/uploads/AltTester/desktop/AltTesterDesktopPackageMac__v2.0.1.zip), then open it.
+- To run the tests, you must include the AltTester Unity SDK in the project. To do that, you can choose between the following ways:
+1. Add the AltTester Unity SDK submodule to the project
     - use ``git submodule update --init`` command to pull the git submodule;
     - make sure that the submodule added is on the master branch (you can use the following command ``git checkout master`` in the <i>Assets/AltTester-Unity-SDK</i> folder);
     - also, if you already have the project, you should make a ``git pull`` on the master branch, in order to ensure that you are using the latest version of AltTester.
 
     <br> 
-3. Download AltTester Unity SDK and import it into Unity 
+2. Download AltTester Unity SDK and import it into Unity 
     - download the AltTester Unity SDK from the AltTester website (https://alttester.com/alttester/#pricing - you will be able to download a package that will contain a unity package) or using this link https://alttester.com/app/uploads/AltTester/sdks/AltTester.unitypackage;
     - import the package into the project (drag-n-drop the package in the Assets folder);
     - a pop-up will appear, select All and click on Import.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To run the tests, you must include the AltTester Unity SDK in the project. To do
 
     <br> 
 3. Download AltTester Unity SDK and import it into Unity 
-    - download the AltTester Unity SDK from the Altom website (https://altom.com/testing-tools/alttester/) or using this link https://altom.com/app/uploads/AltTester/sdks/AltTester.unitypackage;
+    - download the AltTester Unity SDK from the AltTester website (https://alttester.com/alttester/#pricing - you will be able to download a package that will contain a unity package) or using this link https://alttester.com/app/uploads/AltTester/sdks/AltTester.unitypackage;
     - import the package into the project (drag-n-drop the package in the Assets folder);
     - a pop-up will appear, select All and click on Import.
 


### PR DESCRIPTION
Reverts alttester/EXAMPLES-NewInputSystem--CoinCollector-CSharp#7
In this PR will be done:
- Change in tests "Altom" name in imports for C# package
- Update the readme.md

the PR for this issue should be merged on the main branch only when we have the released tester for pro 1.0